### PR TITLE
#11 Feature: Token Refresh

### DIFF
--- a/app/schemas/token.py
+++ b/app/schemas/token.py
@@ -19,3 +19,18 @@ class TokenData(BaseModel):
     """
     user_id: int | None = None
     username: str | None = None
+
+
+class RefreshTokenRequest(BaseModel):
+    """
+    Request schema for token refresh.
+    """
+    refresh_token: str
+
+
+class AccessTokenResponse(BaseModel):
+    """
+    Response with only access token.
+    """
+    access_token: str
+    token_type: str = "bearer"


### PR DESCRIPTION
## Task #11: Token Refresh

### Overview
Implementation of token refresh endpoint that allows users to obtain new access tokens using valid refresh tokens without re-authentication.

### Changes

**Token Schemas (app/schemas/token.py):**
- RefreshTokenRequest: Schema for refresh token request with refresh_token field
- AccessTokenResponse: Response schema with access_token and token_type

**Authentication Endpoint (app/api/v1/endpoints/auth.py):**
- POST /api/v1/auth/refresh: Refresh access token using refresh token
- Validates refresh token signature and expiration
- Checks token type (must be "refresh", not "access")
- Retrieves user from database by user_id in token payload
- Verifies user is active
- Returns new access_token with 30 minutes expiration
- Returns 401 Unauthorized for invalid tokens
- Returns 401 Unauthorized for wrong token type

### Testing
Manually tested via Swagger UI:
- Valid refresh token: 200 OK with new access token
- Invalid refresh token: 401 Unauthorized "Invalid refresh token"
- Access token used instead of refresh: 401 Unauthorized "Invalid token type"
- WWW-Authenticate header present in error responses