### PR TITLE
#47 Feature: Get Task Statistics

### DIFF
--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -145,3 +145,28 @@ class TaskListResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+
+class TaskStatsResponse(BaseModel):
+    """
+    Statistics for current user's tasks.
+    """
+    total: int = Field(
+        ...,
+        description="Total number of tasks for the user",
+        examples=[25],
+    )
+    completed: int = Field(
+        ...,
+        description="Number of completed tasks",
+        examples=[15],
+    )
+    pending: int = Field(
+        ...,
+        description="Number of pending (incomplete) tasks",
+        examples=[10],
+    )
+    completion_rate: float = Field(
+        ...,
+        description="Completion percentage (0-100)",
+        examples=[60.25],
+    )


### PR DESCRIPTION
Реализован эндпоинт GET /api/v1/tasks/stats для получения статистики задач текущего пользователя. Добавлена CRUD-функция get_task_statistics_for_user и схема TaskStatsResponse

Тестирование:
- Проверила, что при отсутствии задач статистика возвращает нули без ошибок
- Через Swagger создала несколько задач для авторизованного пользователя
- Так как эндпоинт переключения статуса выполнения задач ещё не реализован, локально временно устанавливала status=Status.completed при создании задач и проверяла, что значения total, completed, pending и completion_rate корректно пересчитываются в ответе /api/v1/tasks/stats